### PR TITLE
syntax-bugfix in guides/components-and-actions

### DIFF
--- a/src/guides/components-and-actions.md
+++ b/src/guides/components-and-actions.md
@@ -16,7 +16,7 @@ export default class ConferenceSpeakers extends Component {
 
   @tracked('current')
   get moreSpeakers() {
-    return this.speakers.length > this.current;
+    return (this.speakers.length - 1) > this.current;
   }
 
   next() {


### PR DESCRIPTION
`this.current` is an array index and therefore zero based. `this.speakers.length` must be decremented by one to show if there are `moreSpeakers()`