### PR TITLE
add some links to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 The source for the [Glimmer website](https://glimmerjs.com/).
 
+## Related projects
+
+ * [glimmer-application](https://github.com/glimmerjs/glimmer-application)
+ * [glimmer-component](https://github.com/glimmerjs/glimmer-component)
+ * [glimmer-vm](https://github.com/tildeio/glimmer)
+
 ## Running locally
 
 The homepage and guides are powered by [Harp](http://harpjs.com/) and the API


### PR DESCRIPTION
As [glimmerjs.com](https://glimmerjs.com/) links to this repo, it would be good to make it easy for people looking for the actual source

/cc @locks 